### PR TITLE
Switch to PEP 420 native namespace.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 Changelog
 =========
 
-5.2 (unreleased)
+6.0 (unreleased)
 ----------------
 
 - Nothing changed yet.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog
 6.0 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Replace ``pkg_resources`` namespace with PEP 420 native namespace.
 
 
 5.1 (2025-08-07)

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,6 @@
 """
 import os
 
-from setuptools import find_packages
 from setuptools import setup
 
 
@@ -70,16 +69,13 @@ setup(
         'Framework :: Zope :: 3',
     ],
     url='https://github.com/zopefoundation/zope.app.appsetup',
-    packages=find_packages('src'),
-    package_dir={'': 'src'},
-    namespace_packages=['zope', 'zope.app'],
     python_requires='>=3.9',
     extras_require=dict(
         test=[
             'zope.componentvocabulary >= 2.0.0a1',
             'zope.principalregistry >= 4.0.0a1',
             'zope.testing >= 3.10',
-            'zope.testrunner',
+            'zope.testrunner >= 6.4',
         ]
     ),
     install_requires=[

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ def read(*rnames):
 
 setup(
     name='zope.app.appsetup',
-    version='5.2.dev0',
+    version='6.0.dev0',
     author='Zope Foundation and Contributors',
     author_email='zope-dev@zope.dev',
     description="Zope app setup helper",

--- a/src/zope/__init__.py
+++ b/src/zope/__init__.py
@@ -1,1 +1,0 @@
-__import__('pkg_resources').declare_namespace(__name__)  # pragma: no cover

--- a/src/zope/app/__init__.py
+++ b/src/zope/app/__init__.py
@@ -1,1 +1,0 @@
-__import__('pkg_resources').declare_namespace(__name__)  # pragma: no cover


### PR DESCRIPTION
- **Bumped version for breaking release.**
- **Replace ``pkg_resources`` namespace with PEP 420 native namespace.**
- **Switch to PEP 420 native namespace.**
